### PR TITLE
fixes circular arg ref on ruby 2.2.x

### DIFF
--- a/lib/flavour_saver/runtime.rb
+++ b/lib/flavour_saver/runtime.rb
@@ -115,7 +115,7 @@ module FlavourSaver
       end
     end
 
-    def evaluate_call(call, context=context, &block)
+    def evaluate_call(call, context=self.context, &block)
       context = Helpers.decorate_with(context,@helpers,@locals) unless context.is_a? Helpers::Decorator
       case call
       when ParentCallNode


### PR DESCRIPTION
Six specs fail on Ruby 2.2.1 and 2.2.2.  All specs pass w/ this fix.
